### PR TITLE
Cleans all the headers: avoids useless inclusions, includes only nece…

### DIFF
--- a/includes/build_ast.h
+++ b/includes/build_ast.h
@@ -6,14 +6,19 @@
 /*   By: brappo <brappo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/04/10 10:37:10 by brappo            #+#    #+#             */
-/*   Updated: 2024/04/12 11:09:09 by mhotting         ###   ########.fr       */
+/*   Updated: 2024/04/25 12:09:19 by mhotting         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #ifndef BUILD_AST_H
 # define BUILD_AST_H
 
-# include "minishell.h"
+# include <stdbool.h>
+# include <stdlib.h>
+
+typedef struct s_list		t_list;
+typedef struct s_node		t_node;
+typedef enum e_token_type	t_token_type;
 
 bool	set_operator_type(t_list *tokens);
 size_t	array_size(void **array);

--- a/includes/env.h
+++ b/includes/env.h
@@ -6,17 +6,17 @@
 /*   By: mhotting <mhotting@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/04/02 23:48:56 by mhotting          #+#    #+#             */
-/*   Updated: 2024/04/17 13:25:14 by mhotting         ###   ########.fr       */
+/*   Updated: 2024/04/25 10:47:12 by mhotting         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #ifndef ENV_H
 # define ENV_H
 
-# include "minishell.h"
-
 # define ENV_KEY_VALUE_SEPERATOR		'='
 # define ENV_KEY_VALUE_SEPERATOR_STR	"="
+
+typedef struct s_list	t_list;
 
 typedef struct s_env_element
 {

--- a/includes/execution.h
+++ b/includes/execution.h
@@ -6,14 +6,19 @@
 /*   By: mhotting <marvin@42.fr>                    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/04/10 12:52:55 by mhotting          #+#    #+#             */
-/*   Updated: 2024/04/17 11:30:50 by mhotting         ###   ########.fr       */
+/*   Updated: 2024/04/25 11:34:48 by mhotting         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #ifndef EXECUTION_H
 # define EXECUTION_H
 
-# include "minishell.h"
+typedef struct s_minishell			t_minishell;
+typedef struct s_node				t_node;
+typedef struct s_node_command		t_node_command;
+typedef struct s_redirection		t_redirection;
+typedef struct s_redirection_list	t_redirection_list;
+typedef struct s_redirections_info	t_redirections_info;
 
 // General execution
 void	exec_ast(t_minishell *shell, int fds_given[2]);

--- a/includes/expansion.h
+++ b/includes/expansion.h
@@ -6,14 +6,16 @@
 /*   By: brappo <brappo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/04/17 12:31:28 by brappo            #+#    #+#             */
-/*   Updated: 2024/04/18 18:52:32 by brappo           ###   ########.fr       */
+/*   Updated: 2024/04/25 10:52:24 by mhotting         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #ifndef EXPANSION_H
 # define EXPANSION_H
-# include "minishell.h"
 
+# include <stdlib.h>
+
+typedef struct s_list		t_list;
 typedef struct s_minishell	t_minishell;
 
 # define O_QUOTE 1
@@ -31,4 +33,4 @@ t_list	*expand_string(char **str, t_minishell *shell, char options);
 bool	search_wildcards(char *input, t_list **wildcards_pos);
 t_list	*lst_sort(t_list **to_sort, int (*cmp)(void *, void *));
 
-#endif // !EXPANSION_H
+#endif

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -6,32 +6,20 @@
 /*   By: brappo <brappo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/27 10:17:54 by mhotting          #+#    #+#             */
-/*   Updated: 2024/04/19 15:32:09 by mhotting         ###   ########.fr       */
+/*   Updated: 2024/04/25 11:07:08 by mhotting         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #ifndef MINISHELL_H
 # define MINISHELL_H
 
-# include <fcntl.h>
-# include <stdio.h>
-# include <errno.h>
-# include <readline/readline.h>
-# include <readline/history.h>
-# include <dirent.h>
-# include <sys/wait.h>
+# include <stdbool.h>
+# include <stdlib.h>
 # include <sys/types.h>
 
-# include "prompt.h"
-# include "libft.h"
-# include "node.h"
-# include "token.h"
-# include "env.h"
-# include "execution.h"
-# include "pid_list.h"
-# include "built_in.h"
-# include "build_ast.h"
-# include "expansion.h"
+typedef struct s_list		t_list;
+typedef struct s_node		t_node;
+typedef struct s_minishell	t_minishell;
 
 # define STATUS_CMD_NOT_FOUND	127
 # define STATUS_CMD_NOT_EXEC	126
@@ -69,7 +57,7 @@
 
 # define MULTIPLE_LINE_PROMPT	"> "
 
-typedef struct s_minishell
+struct s_minishell
 {
 	char				*input;
 	t_list				*env;
@@ -79,7 +67,7 @@ typedef struct s_minishell
 	t_node				*ast;
 	int					status;
 	t_minishell			*parent;
-}	t_minishell;
+};
 
 // t_minshell functions
 void	t_minishell_init(t_minishell *shell, int ac, char **av, char **envp);

--- a/includes/node.h
+++ b/includes/node.h
@@ -6,16 +6,18 @@
 /*   By: mhotting <marvin@42.fr>                    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/27 17:53:48 by mhotting          #+#    #+#             */
-/*   Updated: 2024/04/12 13:49:25 by mhotting         ###   ########.fr       */
+/*   Updated: 2024/04/25 11:01:59 by mhotting         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #ifndef NODE_H
 # define NODE_H
 
-# include "redirections.h"
+# include <stdbool.h>
 
 # define NUM_NODE_TYPE 5
+
+typedef struct s_list	t_list;
 
 typedef enum e_node_type
 {

--- a/includes/pid_list.h
+++ b/includes/pid_list.h
@@ -6,14 +6,14 @@
 /*   By: mhotting <marvin@42.fr>                    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/04/10 14:50:52 by mhotting          #+#    #+#             */
-/*   Updated: 2024/04/16 11:15:25 by mhotting         ###   ########.fr       */
+/*   Updated: 2024/04/25 10:54:22 by mhotting         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #ifndef PID_LIST_H
 # define PID_LIST_H
 
-# include "minishell.h"
+# include <stdlib.h>
 
 typedef struct s_pid_list
 {

--- a/includes/prompt.h
+++ b/includes/prompt.h
@@ -6,14 +6,14 @@
 /*   By: brappo <brappo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/04/03 13:09:18 by brappo            #+#    #+#             */
-/*   Updated: 2024/04/06 09:56:19 by brappo           ###   ########.fr       */
+/*   Updated: 2024/04/25 10:54:52 by mhotting         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #ifndef PROMPT_H
 # define PROMPT_H
 
-# include "minishell.h"
+# include <stdlib.h>
 
 # define ERROR_MSG_PROMPT "Prompt function error"
 # define ERROR_CWD "Cannot get current working directory path"

--- a/includes/redirections.h
+++ b/includes/redirections.h
@@ -6,14 +6,14 @@
 /*   By: brappo <brappo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/28 11:06:44 by mhotting          #+#    #+#             */
-/*   Updated: 2024/04/12 14:08:47 by mhotting         ###   ########.fr       */
+/*   Updated: 2024/04/25 10:55:34 by mhotting         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #ifndef REDIRECTIONS_H
 # define REDIRECTIONS_H
 
-# include "minishell.h"
+typedef struct s_list	t_list;
 
 enum e_redirection_type
 {

--- a/includes/token.h
+++ b/includes/token.h
@@ -6,16 +6,18 @@
 /*   By: brappo <brappo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/31 19:28:12 by mhotting          #+#    #+#             */
-/*   Updated: 2024/04/19 15:34:13 by mhotting         ###   ########.fr       */
+/*   Updated: 2024/04/25 11:12:22 by mhotting         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #ifndef TOKEN_H
 # define TOKEN_H
 
-# include "minishell.h"
+# include <stdlib.h>
+# include <stdbool.h>
 
 typedef struct s_minishell	t_minishell;
+typedef struct s_list		t_list;
 
 typedef enum e_token_type
 {

--- a/srcs/ast/t_node_and_utils.c
+++ b/srcs/ast/t_node_and_utils.c
@@ -6,11 +6,12 @@
 /*   By: mhotting <marvin@42.fr>                    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/04/10 10:05:19 by mhotting          #+#    #+#             */
-/*   Updated: 2024/04/10 10:34:48 by mhotting         ###   ########.fr       */
+/*   Updated: 2024/04/25 11:02:02 by mhotting         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "minishell.h"
+#include <stdlib.h>
+#include "node.h"
 
 /*
  *	Allocates a t_node of NODE_AND type.

--- a/srcs/ast/t_node_command_utils.c
+++ b/srcs/ast/t_node_command_utils.c
@@ -6,11 +6,14 @@
 /*   By: brappo <brappo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/29 09:54:42 by mhotting          #+#    #+#             */
-/*   Updated: 2024/04/17 14:49:35 by mhotting         ###   ########.fr       */
+/*   Updated: 2024/04/25 11:04:53 by mhotting         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
+#include <stdlib.h>
 #include "minishell.h"
+#include "node.h"
+#include "redirections.h"
 
 /*
  *	Allocates a t_node with an allocated t_node_command as content.

--- a/srcs/ast/t_node_or_utils.c
+++ b/srcs/ast/t_node_or_utils.c
@@ -6,11 +6,12 @@
 /*   By: mhotting <marvin@42.fr>                    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/04/10 10:05:58 by mhotting          #+#    #+#             */
-/*   Updated: 2024/04/10 10:34:54 by mhotting         ###   ########.fr       */
+/*   Updated: 2024/04/25 11:07:34 by mhotting         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "minishell.h"
+#include <stdlib.h>
+#include "node.h"
 
 /*
  *	Allocates a t_node of NODE_OR type.

--- a/srcs/ast/t_node_pipe_utils.c
+++ b/srcs/ast/t_node_pipe_utils.c
@@ -6,11 +6,13 @@
 /*   By: mhotting <marvin@42.fr>                    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/29 09:58:05 by mhotting          #+#    #+#             */
-/*   Updated: 2024/03/29 11:14:25 by mhotting         ###   ########.fr       */
+/*   Updated: 2024/04/25 11:08:03 by mhotting         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
+#include <stdlib.h>
 #include "minishell.h"
+#include "node.h"
 
 /*
  *	Allocates a t_node with an allocated t_node_pipe as content.

--- a/srcs/ast/t_node_subshell_utils.c
+++ b/srcs/ast/t_node_subshell_utils.c
@@ -6,11 +6,15 @@
 /*   By: mhotting <marvin@42.fr>                    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/04/10 10:07:01 by mhotting          #+#    #+#             */
-/*   Updated: 2024/04/10 10:39:53 by mhotting         ###   ########.fr       */
+/*   Updated: 2024/04/25 11:16:34 by mhotting         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "minishell.h"
+#include <stdlib.h>
+#include "libft.h"
+#include "node.h"
+#include "redirections.h"
+#include "token.h"
 
 /*
  *	Allocates a t_node with an allocated t_node_subshell as content.

--- a/srcs/ast/t_node_utils.c
+++ b/srcs/ast/t_node_utils.c
@@ -6,11 +6,13 @@
 /*   By: mhotting <marvin@42.fr>                    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/29 09:51:37 by mhotting          #+#    #+#             */
-/*   Updated: 2024/04/10 10:30:31 by mhotting         ###   ########.fr       */
+/*   Updated: 2024/04/25 11:09:22 by mhotting         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "minishell.h"
+#include <stdlib.h>
+#include "libft.h"
+#include "node.h"
 
 /*
  *	Allocates a t_node and returns a pointer to it.

--- a/srcs/ast/t_redirection_list_utils.c
+++ b/srcs/ast/t_redirection_list_utils.c
@@ -6,11 +6,15 @@
 /*   By: mhotting <marvin@42.fr>                    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/28 08:50:23 by mhotting          #+#    #+#             */
-/*   Updated: 2024/04/11 12:37:26 by mhotting         ###   ########.fr       */
+/*   Updated: 2024/04/25 11:10:18 by mhotting         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
+#include <stdbool.h>
+#include <stdlib.h>
+#include "libft.h"
 #include "minishell.h"
+#include "redirections.h"
 
 /*
  *	Allocates a t_redirection_list and returns a pointer to it.

--- a/srcs/ast/t_redirection_utils.c
+++ b/srcs/ast/t_redirection_utils.c
@@ -6,11 +6,14 @@
 /*   By: brappo <brappo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/28 12:32:34 by mhotting          #+#    #+#             */
-/*   Updated: 2024/03/30 11:35:35 by brappo           ###   ########.fr       */
+/*   Updated: 2024/04/25 11:11:23 by mhotting         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
+#include <stdlib.h>
+#include "libft.h"
 #include "minishell.h"
+#include "redirections.h"
 
 /*
  *	Returns the type of redirection accordig to the given operator

--- a/srcs/ast_building/add_command.c
+++ b/srcs/ast_building/add_command.c
@@ -6,11 +6,15 @@
 /*   By: brappo <brappo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/04/10 12:00:04 by brappo            #+#    #+#             */
-/*   Updated: 2024/04/12 09:26:50 by brappo           ###   ########.fr       */
+/*   Updated: 2024/04/25 11:14:18 by mhotting         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "minishell.h"
+#include <stdlib.h>
+#include "libft.h"
+#include "token.h"
+#include "node.h"
+#include "build_ast.h"
 
 static bool	add_redirections_command(t_list **tokens, t_node *cmd)
 {

--- a/srcs/ast_building/add_operator_node.c
+++ b/srcs/ast_building/add_operator_node.c
@@ -6,11 +6,15 @@
 /*   By: brappo <brappo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/04/10 12:01:32 by brappo            #+#    #+#             */
-/*   Updated: 2024/04/11 12:07:39 by brappo           ###   ########.fr       */
+/*   Updated: 2024/04/25 11:15:41 by mhotting         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "minishell.h"
+#include <stdlib.h>
+#include "libft.h"
+#include "node.h"
+#include "build_ast.h"
+#include "token.h"
 
 bool	add_pipe(t_node **current_node, t_node **head, t_list *tokens)
 {

--- a/srcs/ast_building/add_subshell.c
+++ b/srcs/ast_building/add_subshell.c
@@ -6,11 +6,15 @@
 /*   By: brappo <brappo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/04/10 12:00:49 by brappo            #+#    #+#             */
-/*   Updated: 2024/04/12 09:27:15 by brappo           ###   ########.fr       */
+/*   Updated: 2024/04/25 11:16:25 by mhotting         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "minishell.h"
+#include <stdlib.h>
+#include "libft.h"
+#include "node.h"
+#include "build_ast.h"
+#include "token.h"
 
 static t_list	*get_shell_end(t_list *tokens)
 {

--- a/srcs/ast_building/build_ast.c
+++ b/srcs/ast_building/build_ast.c
@@ -6,11 +6,16 @@
 /*   By: brappo <brappo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/04/10 10:14:38 by brappo            #+#    #+#             */
-/*   Updated: 2024/04/11 12:15:41 by brappo           ###   ########.fr       */
+/*   Updated: 2024/04/25 11:17:12 by mhotting         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "minishell.h"
+#include <stdlib.h>
+#include <stdbool.h>
+#include "libft.h"
+#include "node.h"
+#include "build_ast.h"
+#include "token.h"
 
 t_node	*build_ast(t_list *tokens)
 {

--- a/srcs/ast_building/build_ast_utils.c
+++ b/srcs/ast_building/build_ast_utils.c
@@ -6,11 +6,14 @@
 /*   By: brappo <brappo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/04/10 10:23:01 by brappo            #+#    #+#             */
-/*   Updated: 2024/04/11 10:58:43 by brappo           ###   ########.fr       */
+/*   Updated: 2024/04/25 11:18:08 by mhotting         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
+#include <stdlib.h>
+#include "libft.h"
 #include "minishell.h"
+#include "token.h"
 
 bool	set_operator_type(t_list *tokens)
 {

--- a/srcs/ast_building/get_argv.c
+++ b/srcs/ast_building/get_argv.c
@@ -6,11 +6,14 @@
 /*   By: brappo <brappo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/04/11 11:35:42 by brappo            #+#    #+#             */
-/*   Updated: 2024/04/12 09:27:33 by brappo           ###   ########.fr       */
+/*   Updated: 2024/04/25 11:18:36 by mhotting         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "minishell.h"
+#include <stdlib.h>
+#include <stdbool.h>
+#include "libft.h"
+#include "token.h"
 
 bool	is_redirection(t_token_type token_type)
 {

--- a/srcs/built_in/built_in_utils.c
+++ b/srcs/built_in/built_in_utils.c
@@ -6,11 +6,11 @@
 /*   By: mhotting <marvin@42.fr>                    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/04/12 15:43:07 by mhotting          #+#    #+#             */
-/*   Updated: 2024/04/12 15:44:45 by mhotting         ###   ########.fr       */
+/*   Updated: 2024/04/25 11:19:02 by mhotting         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "minishell.h"
+#include <stdbool.h>
 
 bool	is_built_in(char *cmd_name)
 {

--- a/srcs/env/env_utils.c
+++ b/srcs/env/env_utils.c
@@ -6,11 +6,15 @@
 /*   By: brappo <brappo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/04/03 00:17:49 by mhotting          #+#    #+#             */
-/*   Updated: 2024/04/19 15:34:44 by mhotting         ###   ########.fr       */
+/*   Updated: 2024/04/25 11:20:24 by mhotting         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
+#include <stdlib.h>
+#include <errno.h>
+#include "libft.h"
 #include "minishell.h"
+#include "env.h"
 
 /*
  *	Creates a chained list of t_env_element by extracting data from envp.

--- a/srcs/env/t_env_element_utils.c
+++ b/srcs/env/t_env_element_utils.c
@@ -6,11 +6,15 @@
 /*   By: mhotting <mhotting@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/04/03 02:00:19 by mhotting          #+#    #+#             */
-/*   Updated: 2024/04/12 16:11:59 by mhotting         ###   ########.fr       */
+/*   Updated: 2024/04/25 11:21:09 by mhotting         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
+#include <stdlib.h>
+#include <stdio.h>
+#include "libft.h"
 #include "minishell.h"
+#include "env.h"
 
 /*
  *	Allocates a t_env_element and returns a pointer to it.

--- a/srcs/execution/exec.c
+++ b/srcs/execution/exec.c
@@ -6,11 +6,14 @@
 /*   By: mhotting <mhotting@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/04/14 20:15:29 by mhotting          #+#    #+#             */
-/*   Updated: 2024/04/17 13:24:23 by mhotting         ###   ########.fr       */
+/*   Updated: 2024/04/25 11:30:02 by mhotting         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
+#include <stdlib.h>
 #include "minishell.h"
+#include "execution.h"
+#include "node.h"
 
 /*
  *	Closes the file descriptors stored into the given fds array

--- a/srcs/execution/exec_builtin.c
+++ b/srcs/execution/exec_builtin.c
@@ -6,11 +6,13 @@
 /*   By: mhotting <marvin@42.fr>                    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/04/12 15:39:46 by mhotting          #+#    #+#             */
-/*   Updated: 2024/04/14 19:44:20 by mhotting         ###   ########.fr       */
+/*   Updated: 2024/04/25 11:30:48 by mhotting         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
+#include <stdlib.h>
 #include "minishell.h"
+#include "node.h"
 
 /*
  *	Dummy function (temporary)

--- a/srcs/execution/exec_cmd.c
+++ b/srcs/execution/exec_cmd.c
@@ -6,11 +6,18 @@
 /*   By: mhotting <marvin@42.fr>                    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/04/12 15:40:35 by mhotting          #+#    #+#             */
-/*   Updated: 2024/04/19 14:54:28 by mhotting         ###   ########.fr       */
+/*   Updated: 2024/04/25 11:32:34 by mhotting         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
+#include <stdlib.h>
+#include <unistd.h>
+#include "libft.h"
 #include "minishell.h"
+#include "built_in.h"
+#include "execution.h"
+#include "node.h"
+#include "env.h"
 
 /*
  *	Closes process' stdin and stdout

--- a/srcs/execution/exec_cmd_get_path.c
+++ b/srcs/execution/exec_cmd_get_path.c
@@ -6,11 +6,15 @@
 /*   By: mhotting <mhotting@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/04/14 10:53:09 by mhotting          #+#    #+#             */
-/*   Updated: 2024/04/14 19:52:33 by mhotting         ###   ########.fr       */
+/*   Updated: 2024/04/25 11:33:16 by mhotting         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
+#include <stdlib.h>
+#include <errno.h>
+#include "libft.h"
 #include "minishell.h"
+#include "env.h"
 
 /*
  *	Returns the path to a given command

--- a/srcs/execution/exec_node_command.c
+++ b/srcs/execution/exec_node_command.c
@@ -6,11 +6,17 @@
 /*   By: mhotting <marvin@42.fr>                    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/04/10 12:39:49 by mhotting          #+#    #+#             */
-/*   Updated: 2024/04/19 14:57:41 by mhotting         ###   ########.fr       */
+/*   Updated: 2024/04/25 11:35:28 by mhotting         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
+#include <stdlib.h>
+#include <unistd.h>
 #include "minishell.h"
+#include "built_in.h"
+#include "redirections.h"
+#include "execution.h"
+#include "node.h"
 
 /*
  *	Sets command file descriptors according to the given ones

--- a/srcs/execution/exec_node_logical.c
+++ b/srcs/execution/exec_node_logical.c
@@ -6,11 +6,16 @@
 /*   By: mhotting <marvin@42.fr>                    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/04/15 09:41:09 by mhotting          #+#    #+#             */
-/*   Updated: 2024/04/16 12:44:27 by mhotting         ###   ########.fr       */
+/*   Updated: 2024/04/25 11:36:27 by mhotting         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
+#include <stdlib.h>
+#include <unistd.h>
+#include <stdbool.h>
 #include "minishell.h"
+#include "execution.h"
+#include "node.h"
 
 /*
  *	Clones the files descriptors stored into fds_src into fds_dest

--- a/srcs/execution/exec_node_pipe.c
+++ b/srcs/execution/exec_node_pipe.c
@@ -6,11 +6,15 @@
 /*   By: mhotting <mhotting@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/04/14 19:49:27 by mhotting          #+#    #+#             */
-/*   Updated: 2024/04/17 11:57:09 by mhotting         ###   ########.fr       */
+/*   Updated: 2024/04/25 11:37:13 by mhotting         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
+#include <stdlib.h>
+#include <unistd.h>
 #include "minishell.h"
+#include "execution.h"
+#include "node.h"
 
 /*
  *	Executes a node of type NODE_PIPE into the given shell

--- a/srcs/execution/exec_node_subshell.c
+++ b/srcs/execution/exec_node_subshell.c
@@ -6,11 +6,17 @@
 /*   By: mhotting <mhotting@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/04/16 13:52:21 by mhotting          #+#    #+#             */
-/*   Updated: 2024/04/17 14:05:45 by mhotting         ###   ########.fr       */
+/*   Updated: 2024/04/25 11:38:16 by mhotting         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
+#include <stdlib.h>
+#include <unistd.h>
 #include "minishell.h"
+#include "execution.h"
+#include "node.h"
+#include "redirections.h"
+#include "build_ast.h"
 
 /*
  *	Frees the memory, closes the given fds and exits the program with error

--- a/srcs/execution/exec_redirection_list1.c
+++ b/srcs/execution/exec_redirection_list1.c
@@ -1,16 +1,20 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   execution_redirection_list1.c                      :+:      :+:    :+:   */
+/*   exec_redirection_list1.c                           :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: mhotting <marvin@42.fr>                    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/04/11 12:37:09 by mhotting          #+#    #+#             */
-/*   Updated: 2024/04/12 14:19:24 by mhotting         ###   ########.fr       */
+/*   Updated: 2024/04/25 11:38:59 by mhotting         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "minishell.h"
+#include <stdlib.h>
+#include <stdbool.h>
+#include "libft.h"
+#include "execution.h"
+#include "redirections.h"
 
 /*
  *	Executes a redirection depending on its type

--- a/srcs/execution/exec_redirection_list2.c
+++ b/srcs/execution/exec_redirection_list2.c
@@ -6,11 +6,16 @@
 /*   By: mhotting <marvin@42.fr>                    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/04/11 12:37:09 by mhotting          #+#    #+#             */
-/*   Updated: 2024/04/15 15:56:18 by mhotting         ###   ########.fr       */
+/*   Updated: 2024/04/25 11:40:23 by mhotting         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
+#include <stdlib.h>
+#include <stdbool.h>
+#include <fcntl.h>
+#include "libft.h"
 #include "minishell.h"
+#include "redirections.h"
 
 /*
  *	Reads lines from STDIN_FILENO and writes them into the given fd_to_write

--- a/srcs/expansion/expand_string.c
+++ b/srcs/expansion/expand_string.c
@@ -6,11 +6,14 @@
 /*   By: brappo <brappo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/04/05 15:12:32 by brappo            #+#    #+#             */
-/*   Updated: 2024/04/24 09:45:17 by brappo           ###   ########.fr       */
+/*   Updated: 2024/04/25 11:41:49 by mhotting         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "minishell.h"
+#include <stdbool.h>
+#include "libft.h"
+#include "token.h"
+#include "expansion.h"
 
 static void	remove_quote(t_token_parser *parser, char *input, char options)
 {

--- a/srcs/expansion/expand_wildcard.c
+++ b/srcs/expansion/expand_wildcard.c
@@ -6,11 +6,16 @@
 /*   By: brappo <brappo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/04/12 10:28:30 by brappo            #+#    #+#             */
-/*   Updated: 2024/04/24 09:48:10 by brappo           ###   ########.fr       */
+/*   Updated: 2024/04/25 11:43:26 by mhotting         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "minishell.h"
+#include <stdlib.h>
+#include <sys/types.h>
+#include <dirent.h>
+#include "libft.h"
+#include "token.h"
+#include "expansion.h"
 
 static int	alphabetic_compare(void *a, void *b)
 {

--- a/srcs/expansion/get_variable_key.c
+++ b/srcs/expansion/get_variable_key.c
@@ -6,11 +6,12 @@
 /*   By: brappo <brappo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/04/04 08:34:50 by brappo            #+#    #+#             */
-/*   Updated: 2024/04/17 11:39:08 by brappo           ###   ########.fr       */
+/*   Updated: 2024/04/25 11:43:55 by mhotting         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "minishell.h"
+#include <stdbool.h>
+#include "libft.h"
 
 static bool	is_char_name(char c)
 {

--- a/srcs/expansion/string_equal_wildcard.c
+++ b/srcs/expansion/string_equal_wildcard.c
@@ -6,11 +6,13 @@
 /*   By: root <root@student.42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/04/11 12:39:55 by brappo            #+#    #+#             */
-/*   Updated: 2024/04/12 19:47:20 by root             ###   ########.fr       */
+/*   Updated: 2024/04/25 11:44:32 by mhotting         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "minishell.h"
+#include <stdlib.h>
+#include <stdbool.h>
+#include "libft.h"
 
 bool	is_wildcard(char *characters, t_list *wildcards)
 {

--- a/srcs/expansion/word_expansion.c
+++ b/srcs/expansion/word_expansion.c
@@ -6,11 +6,17 @@
 /*   By: brappo <brappo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/04/04 14:03:37 by brappo            #+#    #+#             */
-/*   Updated: 2024/04/19 15:35:09 by mhotting         ###   ########.fr       */
+/*   Updated: 2024/04/25 11:45:55 by mhotting         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
+#include <stdlib.h>
+#include <stdbool.h>
+#include <errno.h>
+#include "libft.h"
 #include "minishell.h"
+#include "env.h"
+#include "expansion.h"
 
 static bool	replace_key(char **input, ssize_t *key_coordinates, char *value,
 	size_t variable_start)

--- a/srcs/main/minishell.c
+++ b/srcs/main/minishell.c
@@ -6,11 +6,19 @@
 /*   By: brappo <brappo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/27 10:14:16 by mhotting          #+#    #+#             */
-/*   Updated: 2024/04/19 15:35:33 by mhotting         ###   ########.fr       */
+/*   Updated: 2024/04/25 11:50:22 by mhotting         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
+#include <stdbool.h>
+#include <readline/history.h>
 #include "minishell.h"
+#include "prompt.h"
+#include "libft.h"
+#include "token.h"
+#include "node.h"
+#include "build_ast.h"
+#include "execution.h"
 
 int	main(int argc, char **argv, char **envp)
 {

--- a/srcs/prompt/directory_utils.c
+++ b/srcs/prompt/directory_utils.c
@@ -6,11 +6,15 @@
 /*   By: root <root@student.42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/28 12:54:36 by brappo            #+#    #+#             */
-/*   Updated: 2024/04/12 18:52:13 by root             ###   ########.fr       */
+/*   Updated: 2024/04/25 11:47:01 by mhotting         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
+#include <stdlib.h>
+#include <errno.h>
+#include "libft.h"
 #include "minishell.h"
+#include "prompt.h"
 
 void	set_color(char *start_color, size_t end_color,
 		char *color, size_t buffer_size)

--- a/srcs/prompt/prompt_handler.c
+++ b/srcs/prompt/prompt_handler.c
@@ -6,11 +6,14 @@
 /*   By: brappo <brappo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/27 13:02:08 by mhotting          #+#    #+#             */
-/*   Updated: 2024/04/04 11:43:30 by brappo           ###   ########.fr       */
+/*   Updated: 2024/04/25 11:50:36 by mhotting         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
+#include <stdlib.h>
+#include <readline/readline.h>
 #include "minishell.h"
+#include "prompt.h"
 
 char	*prompt(t_minishell *shell)
 {

--- a/srcs/tokenRecognition/handle_quote.c
+++ b/srcs/tokenRecognition/handle_quote.c
@@ -6,11 +6,12 @@
 /*   By: brappo <brappo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/28 09:56:51 by brappo            #+#    #+#             */
-/*   Updated: 2024/03/28 09:58:04 by brappo           ###   ########.fr       */
+/*   Updated: 2024/04/25 11:51:08 by mhotting         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "minishell.h"
+#include <stdbool.h>
+#include "token.h"
 
 bool	is_quoted(t_token_parser *token_parser)
 {

--- a/srcs/tokenRecognition/is_operator.c
+++ b/srcs/tokenRecognition/is_operator.c
@@ -6,11 +6,12 @@
 /*   By: brappo <brappo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/28 10:40:53 by brappo            #+#    #+#             */
-/*   Updated: 2024/04/10 11:13:26 by brappo           ###   ########.fr       */
+/*   Updated: 2024/04/25 11:51:27 by mhotting         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
+#include "token.h"
 
 void	get_operation(char **operations)
 {

--- a/srcs/tokenRecognition/token_list_merge.c
+++ b/srcs/tokenRecognition/token_list_merge.c
@@ -6,11 +6,14 @@
 /*   By: brappo <brappo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/04/02 20:42:20 by root              #+#    #+#             */
-/*   Updated: 2024/04/12 09:26:27 by brappo           ###   ########.fr       */
+/*   Updated: 2024/04/25 11:52:06 by mhotting         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
+#include <stdlib.h>
+#include "libft.h"
 #include "minishell.h"
+#include "token.h"
 
 /*
 	When merging tokens, the "next" string is joined with the "first" string.

--- a/srcs/tokenRecognition/token_recognition.c
+++ b/srcs/tokenRecognition/token_recognition.c
@@ -6,11 +6,15 @@
 /*   By: brappo <brappo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/04/02 13:01:05 by brappo            #+#    #+#             */
-/*   Updated: 2024/04/17 11:24:21 by brappo           ###   ########.fr       */
+/*   Updated: 2024/04/25 11:52:55 by mhotting         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "minishell.h" 
+#include <stdlib.h>
+#include "libft.h"
+#include "minishell.h"
+#include "token.h"
+#include <readline/readline.h>
 
 static bool	add_end_token(t_list **tokens)
 {

--- a/srcs/tokenRecognition/token_recognition_utils.c
+++ b/srcs/tokenRecognition/token_recognition_utils.c
@@ -6,11 +6,14 @@
 /*   By: brappo <brappo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/27 15:09:19 by brappo            #+#    #+#             */
-/*   Updated: 2024/04/18 10:18:28 by brappo           ###   ########.fr       */
+/*   Updated: 2024/04/25 11:53:49 by mhotting         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "minishell.h"
+#include <stdlib.h>
+#include <stdbool.h>
+#include "libft.h"
+#include "token.h"
 
 void	t_token_parser_init(t_token_parser *token_parser)
 {

--- a/srcs/tokenRecognition/tokenize_str.c
+++ b/srcs/tokenRecognition/tokenize_str.c
@@ -6,11 +6,15 @@
 /*   By: brappo <brappo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/27 14:59:56 by brappo            #+#    #+#             */
-/*   Updated: 2024/04/17 09:36:40 by brappo           ###   ########.fr       */
+/*   Updated: 2024/04/25 11:54:37 by mhotting         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
+#include <stdlib.h>
+#include <stdbool.h>
+#include "libft.h"
 #include "minishell.h"
+#include "token.h"
 
 static bool	is_token_end(t_token *token, char character, \
 		t_token_parser *token_parser)

--- a/srcs/utils/array_utils.c
+++ b/srcs/utils/array_utils.c
@@ -6,11 +6,12 @@
 /*   By: brappo <brappo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/28 10:22:22 by brappo            #+#    #+#             */
-/*   Updated: 2024/04/10 13:52:08 by brappo           ###   ########.fr       */
+/*   Updated: 2024/04/25 11:55:07 by mhotting         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "minishell.h"
+#include <stdlib.h>
+#include <stdbool.h>
 
 int	array_find(void **array, bool (equal)(void *a, void *b), void *value)
 {

--- a/srcs/utils/close_file_descriptor.c
+++ b/srcs/utils/close_file_descriptor.c
@@ -6,10 +6,12 @@
 /*   By: mhotting <marvin@42.fr>                    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/28 12:26:18 by mhotting          #+#    #+#             */
-/*   Updated: 2024/03/29 11:13:37 by mhotting         ###   ########.fr       */
+/*   Updated: 2024/04/25 11:55:48 by mhotting         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
+#include <stdlib.h>
+#include <unistd.h>
 #include "minishell.h"
 
 /*

--- a/srcs/utils/error.c
+++ b/srcs/utils/error.c
@@ -6,10 +6,14 @@
 /*   By: brappo <brappo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/27 13:24:53 by mhotting          #+#    #+#             */
-/*   Updated: 2024/04/15 15:45:47 by mhotting         ###   ########.fr       */
+/*   Updated: 2024/04/25 11:56:52 by mhotting         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
+#include <stdlib.h>
+#include <errno.h>
+#include <string.h>
+#include "libft.h"
 #include "minishell.h"
 
 /*

--- a/srcs/utils/ft_print_str_array.c
+++ b/srcs/utils/ft_print_str_array.c
@@ -6,11 +6,11 @@
 /*   By: mhotting <marvin@42.fr>                    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/04/04 14:02:21 by mhotting          #+#    #+#             */
-/*   Updated: 2024/04/04 14:05:27 by mhotting         ###   ########.fr       */
+/*   Updated: 2024/04/25 11:57:08 by mhotting         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "minishell.h"
+#include <stdio.h>
 
 /*
  *	Prints a NULL terminated array of strings

--- a/srcs/utils/ft_split_key_val.c
+++ b/srcs/utils/ft_split_key_val.c
@@ -6,11 +6,14 @@
 /*   By: mhotting <marvin@42.fr>                    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/04/04 09:58:22 by mhotting          #+#    #+#             */
-/*   Updated: 2024/04/04 12:36:18 by mhotting         ###   ########.fr       */
+/*   Updated: 2024/04/25 11:57:44 by mhotting         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "minishell.h"
+#include <stdlib.h>
+#include <stdbool.h>
+#include <errno.h>
+#include "libft.h"
 
 /*
  *	Tests if str has the valid form: "<KEY><SEP><VALUE>"

--- a/srcs/utils/list_utils.c
+++ b/srcs/utils/list_utils.c
@@ -6,11 +6,11 @@
 /*   By: brappo <brappo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/28 09:32:38 by brappo            #+#    #+#             */
-/*   Updated: 2024/04/18 16:59:21 by brappo           ###   ########.fr       */
+/*   Updated: 2024/04/25 12:03:46 by mhotting         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "minishell.h"
+#include "libft.h"
 
 t_list	*lst_push_front_content(t_list **head,
 	void *content, void free_content(void *))

--- a/srcs/utils/string_utils.c
+++ b/srcs/utils/string_utils.c
@@ -6,11 +6,13 @@
 /*   By: brappo <brappo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/28 10:26:15 by brappo            #+#    #+#             */
-/*   Updated: 2024/04/17 11:34:23 by brappo           ###   ########.fr       */
+/*   Updated: 2024/04/25 11:58:12 by mhotting         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "minishell.h"
+#include <stdlib.h>
+#include <stdbool.h>
+#include "libft.h"
 
 bool	is_prefix(void	*word, void *prefix)
 {

--- a/srcs/utils/t_minishell_utils1.c
+++ b/srcs/utils/t_minishell_utils1.c
@@ -6,11 +6,19 @@
 /*   By: brappo <brappo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/27 13:10:16 by mhotting          #+#    #+#             */
-/*   Updated: 2024/04/17 13:33:10 by mhotting         ###   ########.fr       */
+/*   Updated: 2024/04/25 12:00:12 by mhotting         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
+#include <stdlib.h>
+#include <stdbool.h>
+#include <readline/readline.h>
+#include "libft.h"
 #include "minishell.h"
+#include "env.h"
+#include "token.h"
+#include "node.h"
+#include "pid_list.h"
 
 /*
  *	Initializes the given shell with empty fields

--- a/srcs/utils/t_minishell_utils2.c
+++ b/srcs/utils/t_minishell_utils2.c
@@ -6,11 +6,16 @@
 /*   By: brappo <brappo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/27 13:10:16 by mhotting          #+#    #+#             */
-/*   Updated: 2024/04/17 13:38:02 by mhotting         ###   ########.fr       */
+/*   Updated: 2024/04/25 12:01:21 by mhotting         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
+#include <stdlib.h>
+#include <stdbool.h>
+#include <errno.h>
+#include <sys/wait.h>
 #include "minishell.h"
+#include "pid_list.h"
 
 /*
  *	Adds a pid to the given shell's pid list

--- a/srcs/utils/t_pid_list_utils.c
+++ b/srcs/utils/t_pid_list_utils.c
@@ -6,11 +6,14 @@
 /*   By: mhotting <marvin@42.fr>                    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/04/10 14:54:49 by mhotting          #+#    #+#             */
-/*   Updated: 2024/04/16 11:15:00 by mhotting         ###   ########.fr       */
+/*   Updated: 2024/04/25 12:02:16 by mhotting         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "minishell.h"
+#include <stdlib.h>
+#include <sys/types.h>
+#include "libft.h"
+#include "pid_list.h"
 
 /*
  *	Allocates a t_pid_list element and returns a pointer to it


### PR DESCRIPTION
J'ai remarqué que la compilation de notre projet devenait lente et j'ai cherché pourquoi. Notre façon de gérer les headers était mauvaise.
Le fait d'inclure tout le temps `minishell.h` qui inclut tous les autres headers provoque des inclusions en cascade qui sont nuisibles à la compilation.
Voici donc ce que j'ai fait:
- j'ai retiré toutes les inclusions inutiles dans `minishell.h`
- j'ai retiré toutes les inclusions de `minishell.h`  des tous les fichiers
- je suis repassé sur tous les fichiers un par un pour n'inclure que les headers nécessaires
- lorsque c'est nécesaire, dans les fichiers `*.h` j'ai écrit des typedef pour que les types soient accessibles (ils appellent ça les `forward declarations`)

La compilation est plus rapide et ça semble être une meilleure pratique de code.
Je crée et ferme la PR moi-même parce qu'elle n'a pas d'intérêt de relecture mais tu peux ainsi la consulter si tu veux voir ce qui a été fait ou si quelque-chose te semble incorrect.