### PR TITLE
Pasted input

### DIFF
--- a/config/sources.mk
+++ b/config/sources.mk
@@ -6,7 +6,7 @@
 #    By: root <root@student.42.fr>                  +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2024/03/31 20:47:09 by mhotting          #+#    #+#              #
-#    Updated: 2024/05/12 18:37:05 by root             ###   ########.fr        #
+#    Updated: 2024/05/13 22:06:21 by root             ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -106,7 +106,8 @@ TOKENR					=	$(addprefix $(TOKENR_DIR), $(TOKENR_FILES))
 PROMPT_DIR				=	prompt/
 PROMPT_FILES			=	prompt_handler.c 			\
 							directory_utils.c			\
-							readline_not_tty.c
+							readline_not_tty.c			\
+							read_one_line.c
 PROMPT					=	$(addprefix $(PROMPT_DIR), $(PROMPT_FILES))
 
 # VARIABLE EXPANSION

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -6,7 +6,7 @@
 /*   By: root <root@student.42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/27 10:17:54 by mhotting          #+#    #+#             */
-/*   Updated: 2024/05/13 10:15:45 by mhotting         ###   ########.fr       */
+/*   Updated: 2024/05/13 22:13:24 by root             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -127,5 +127,5 @@ bool	string_contains_only_spaces(char *str);
 bool	string_contains_invalid_chars(char *str);
 void	**to_array(t_list *lst);
 bool	utils_is_empty_cmd(char *cmd);
-
+size_t	array_size(void **array);;
 #endif

--- a/includes/prompt.h
+++ b/includes/prompt.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   prompt.h                                           :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: brappo <brappo@student.42.fr>              +#+  +:+       +#+        */
+/*   By: root <root@student.42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/04/03 13:09:18 by brappo            #+#    #+#             */
-/*   Updated: 2024/05/13 10:15:55 by mhotting         ###   ########.fr       */
+/*   Updated: 2024/05/13 21:48:14 by root             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -29,5 +29,6 @@ typedef struct s_minishell	t_minishell;
 bool	get_directory_path(t_list *env, char *buffer, size_t buffer_size);
 char	*prompt(t_minishell *shell);
 char	*readline_not_tty(void);
+char	*read_one_line(char *prompt);
 
 #endif

--- a/srcs/built_in/exit.c
+++ b/srcs/built_in/exit.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   exit.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: mhotting <marvin@42.fr>                    +#+  +:+       +#+        */
+/*   By: root <root@student.42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/04/24 11:03:49 by mhotting          #+#    #+#             */
-/*   Updated: 2024/05/13 15:56:04 by mhotting         ###   ########.fr       */
+/*   Updated: 2024/05/14 08:34:54 by root             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -40,7 +40,6 @@ static void	bi_exit_shell_ok(t_minishell *shell, int status, char *msg)
 		t_minishell_free(shell);
 	exit(status);
 }
-
 
 /*
  *	Checks is the given string is a valid exit status

--- a/srcs/execution/exec_cmd_get_path.c
+++ b/srcs/execution/exec_cmd_get_path.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   exec_cmd_get_path.c                                :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: mhotting <mhotting@student.42.fr>          +#+  +:+       +#+        */
+/*   By: root <root@student.42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/04/14 10:53:09 by mhotting          #+#    #+#             */
-/*   Updated: 2024/05/13 15:37:56 by mhotting         ###   ########.fr       */
+/*   Updated: 2024/05/13 22:12:57 by root             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -32,7 +32,7 @@ static bool	is_valid_cmd_path(char *path, int *status)
 		errno = 0;
 		return (false);
 	}
-	if (S_ISDIR(file_info.st_mode) ||  access(path, F_OK) != 0)
+	if (S_ISDIR(file_info.st_mode) || access(path, F_OK) != 0)
 	{
 		*status = STATUS_CMD_NOT_FOUND;
 		return (false);

--- a/srcs/execution/exec_redirection_list_hdcs.c
+++ b/srcs/execution/exec_redirection_list_hdcs.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   exec_redirection_list_hdcs.c                       :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: brappo <brappo@student.42.fr>              +#+  +:+       +#+        */
+/*   By: root <root@student.42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/03 15:35:13 by mhotting          #+#    #+#             */
-/*   Updated: 2024/05/13 12:29:51 by brappo           ###   ########.fr       */
+/*   Updated: 2024/05/13 21:47:08 by root             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -49,7 +49,7 @@ static char	*read_input(t_minishell *shell)
 	char	*line;
 
 	if (shell->is_a_tty)
-		line = readline(HEREDOC_PROMPT);
+		line = read_one_line(HEREDOC_PROMPT);
 	else
 		line = readline_not_tty();
 	return (line);

--- a/srcs/main/minishell.c
+++ b/srcs/main/minishell.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   minishell.c                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: brappo <brappo@student.42.fr>              +#+  +:+       +#+        */
+/*   By: root <root@student.42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/27 10:14:16 by mhotting          #+#    #+#             */
-/*   Updated: 2024/05/13 16:23:23 by brappo           ###   ########.fr       */
+/*   Updated: 2024/05/13 21:49:27 by root             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -96,7 +96,6 @@ static int	project_main_loop(t_minishell *shell)
 		return (STATUS_INVALID_USE);
 	}
 	token_recognition(shell);
-	ft_lstprint(shell->tokens, print_token);
 	if (get_sigint())
 		return (STATUS_SIGINT_STOP);
 	shell->ast = build_ast(shell->tokens);

--- a/srcs/prompt/prompt_handler.c
+++ b/srcs/prompt/prompt_handler.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   prompt_handler.c                                   :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: brappo <brappo@student.42.fr>              +#+  +:+       +#+        */
+/*   By: root <root@student.42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/27 13:02:08 by mhotting          #+#    #+#             */
-/*   Updated: 2024/05/13 13:52:08 by brappo           ###   ########.fr       */
+/*   Updated: 2024/05/13 22:05:59 by root             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -29,14 +29,14 @@ static char	*read_input(char *prompt, t_minishell *shell)
 {
 	char	*input;
 
-	input = readline(prompt);
+	input = read_one_line(prompt);
 	while ((errno == EINTR || errno == 0) && get_sigint())
 	{
 		set_interactive_mode(true);
 		shell->status = 130;
 		errno = 0;
 		free(input);
-		input = readline(prompt);
+		input = read_one_line(prompt);
 	}
 	return (input);
 }

--- a/srcs/prompt/read_one_line.c
+++ b/srcs/prompt/read_one_line.c
@@ -1,0 +1,59 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   read_one_line.c                                    :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: root <root@student.42.fr>                  +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/05/13 22:05:38 by root              #+#    #+#             */
+/*   Updated: 2024/05/13 22:11:53 by root             ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include <readline/readline.h>
+#include "minishell.h"
+#include "libft.h"
+
+static char	*extract_first_line(char **lines)
+{
+	char	*input;
+
+	input = lines[0];
+	ft_memmove(lines, lines + 1, array_size((void **)lines) * sizeof(char *));
+	return (input);
+}
+
+static void	free_and_reset(void **malloced_str)
+{
+	free(*malloced_str);
+	*malloced_str = NULL;
+}
+
+char	*read_one_line(char *prompt)
+{
+	static char	**lines = NULL;
+	char		*input;
+
+	if (prompt == NULL)
+	{
+		ft_free_str_array(&lines);
+		return (NULL);
+	}
+	if (lines != NULL)
+	{
+		if (lines[0] != NULL)
+			return (extract_first_line(lines));
+		else
+			free_and_reset((void **)&lines);
+	}
+	input = readline(prompt);
+	if (ft_strchr(input, '\n'))
+	{
+		lines = ft_split(input, "\n");
+		free(input);
+		if (lines == NULL)
+			return (NULL);
+		input = extract_first_line(lines);
+	}
+	return (input);
+}

--- a/srcs/tokenRecognition/token_recognition.c
+++ b/srcs/tokenRecognition/token_recognition.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   token_recognition.c                                :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: brappo <brappo@student.42.fr>              +#+  +:+       +#+        */
+/*   By: root <root@student.42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/04/02 13:01:05 by brappo            #+#    #+#             */
-/*   Updated: 2024/05/13 13:51:37 by brappo           ###   ########.fr       */
+/*   Updated: 2024/05/13 21:45:27 by root             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -83,7 +83,7 @@ static t_list	*tokenize_input(t_minishell *shell,
 	t_list	*tokens;
 
 	if (shell->is_a_tty)
-		input = readline(MULTIPLE_LINE_PROMPT);
+		input = read_one_line(MULTIPLE_LINE_PROMPT);
 	else
 		input = readline_not_tty();
 	if (get_sigint())

--- a/srcs/utils/t_minishell_utils1.c
+++ b/srcs/utils/t_minishell_utils1.c
@@ -6,7 +6,7 @@
 /*   By: root <root@student.42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/27 13:10:16 by mhotting          #+#    #+#             */
-/*   Updated: 2024/05/13 14:18:36 by mhotting         ###   ########.fr       */
+/*   Updated: 2024/05/13 21:47:39 by root             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -21,6 +21,7 @@
 #include "env.h"
 #include "token.h"
 #include "node.h"
+#include "prompt.h"
 #include "pid_list.h"
 
 /*
@@ -54,6 +55,7 @@ void	t_minishell_init(t_minishell *shell, int argc, char **argv, char **envp)
 void	t_minishell_free(t_minishell *shell)
 {
 	rl_clear_history();
+	read_one_line(NULL);
 	if (shell == NULL)
 		return ;
 	if (shell->parent != NULL)


### PR DESCRIPTION
Ajout de read_one_line qui permet d'obtenir l'input ligne par ligne, même si il a été copié.

la fonction, lorsque l'input fait plusieurs lignes, enregistre chaque ligne dans un tableau static de string.
Les prochains appels de cette fonction iront d'abord chercher dans le tableau de string avant de réappeler readline.
Lorsque l'on a récupéré toutes les lignes du tableau static, on le free te le met à NULL.
j'ai remplacé tous les appels de readline par read_one_line.

L'appel de read_one_line avec prompt à NULL free le tableau static.
t_minishell_free appel read_one_line(NULL)